### PR TITLE
fixing crash in TreeNode.delete caused by TreeNode.minValueNode() returns always nil

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -14,3 +14,4 @@ Google Inc.
 EXARING AG
 Oliver Herms
 Julian Kornberger
+Cedric Kienzler

--- a/avltree/avtltree.go
+++ b/avltree/avtltree.go
@@ -60,7 +60,7 @@ func (root *TreeNode) getHeight() int64 {
 
 // TreeMinValueNode returns the node with the minimal key in the tree
 func (root *TreeNode) minValueNode() *TreeNode {
-	for root.left == nil {
+	if root.left == nil {
 		// If no left element is available, we are at the smallest key
 		// so we return ourself
 		return root

--- a/avltree/avtltree.go
+++ b/avltree/avtltree.go
@@ -60,10 +60,13 @@ func (root *TreeNode) getHeight() int64 {
 
 // TreeMinValueNode returns the node with the minimal key in the tree
 func (root *TreeNode) minValueNode() *TreeNode {
-	for root.left != nil {
-		return root.left.minValueNode()
+	for root.left == nil {
+		// If no left element is available, we are at the smallest key
+		// so we return ourself
+		return root
 	}
-	return nil
+
+	return root.left.minValueNode()
 }
 
 // search searches element with key `key` in tree with root `root`


### PR DESCRIPTION
Fix the function TreeNode.minValueNode() which always returns nil
    
This would lead to a crash in TreeNode.delete at line 159, since minValueNode() always returned nil and then in line 159 to 161 we would have a nil-ptr access which would lead to a crash.
Therefore i introduce this small fix that return the object itself in TreeNode.minValue() when there is no left element left.
